### PR TITLE
Fix: LJ-11 Red Platforms and Pause->MainMenu

### DIFF
--- a/Assets/Prefabs/Platforms/Platform Break.prefab
+++ b/Assets/Prefabs/Platforms/Platform Break.prefab
@@ -51,7 +51,7 @@ MonoBehaviour:
   onPlatformUsed:
     m_PersistentCalls:
       m_Calls: []
-  breakTime: 1.5
+  breakTime: 0.1
   playerLayer:
     serializedVersion: 2
     m_Bits: 8

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -813,7 +813,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 865443834}
         m_TargetAssemblyTypeName: Systems.Manager.GameManager, Assembly-CSharp
-        m_MethodName: SkipRevive
+        m_MethodName: GoMainMenu
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/Systems/Level/Platforms/Platform.cs
+++ b/Assets/Systems/Level/Platforms/Platform.cs
@@ -29,7 +29,7 @@ namespace Systems.Level.Platforms
             _platformData.hasBeenUsed = false;
         }
 
-        protected virtual void OnUsedPlatform()
+        public virtual void OnUsedPlatform()
         {
             _platformData.hasBeenUsed = true;
             onPlatformUsed.Invoke();
@@ -76,6 +76,15 @@ namespace Systems.Level.Platforms
             if (other.CompareTag("DestroyPlatform"))
             {
                 DestroyPlatform();
+            }
+        }
+
+        private void OnCollisionEnter2D(Collision2D collision)
+        {
+            if (collision.gameObject.CompareTag("Player"))
+            {
+                //OnUsedPlatform();
+                Debug.Log("[Platform] Collision");
             }
         }
 

--- a/Assets/Systems/Level/Platforms/PlatformBreak.cs
+++ b/Assets/Systems/Level/Platforms/PlatformBreak.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Runtime.CompilerServices;
 using Systems.Audio;
 using Systems.Level.Data;
 using UnityEngine;
@@ -40,27 +41,28 @@ namespace Systems.Level.Platforms
                 .setEase(LeanTweenType.easeInOutSine);
         }
 
-        protected override void OnUsedPlatform()
+        public override void OnUsedPlatform()
         {
             base.OnUsedPlatform();
             if (_isUsed)
             {
                 return;
             }
-            StartCoroutine(Break());
         }
 
         #endregion
 
-        private IEnumerator Break()
+        public void BreakLand()
         {
-            _isUsed = true;
             landedEffect.Play();
-            yield return new WaitForSeconds(breakTime);
-            breakEffect.Play();
             AudioManager.Instance.PlaySfx("Platform", 1);
-            yield return new WaitForSeconds(breakTime);
-            _isUsed = false;
+
+            Invoke(nameof(BreakDestroy), breakTime);
+        }
+
+        public void BreakDestroy()
+        {
+            breakEffect.Play();
             DestroyPlatform();
         }
     }

--- a/Assets/Systems/Manager/GameManager.cs
+++ b/Assets/Systems/Manager/GameManager.cs
@@ -117,5 +117,11 @@ namespace Systems.Manager
             
             Debug.Log("[GameManager] Skip Revive");
         }
+
+        public void GoMainMenu()
+        {
+            SceneManager.Instance.LoadScene("MainMenuScene");
+            ResumeGame();
+        }
     }
 }

--- a/Assets/Systems/Player/PlayerJump.cs
+++ b/Assets/Systems/Player/PlayerJump.cs
@@ -1,7 +1,8 @@
 using Systems.Audio;
 using Unity.Cinemachine;
 using UnityEngine;
-using Systems.Level; // Necesario para RisingDeathZone
+using Systems.Level;
+using Systems.Level.Platforms; // Necesario para RisingDeathZone
 
 namespace Systems.Player
 {
@@ -67,6 +68,15 @@ namespace Systems.Player
                 _rb.linearVelocityY <= 0 && collision.transform.position.y <= groundCheck.position.y)
             {
                 Jump();
+
+                if (collision.transform.parent != null)
+                {
+                    Platform platform = collision.transform.parent.GetComponent<Platform>();
+                    if (platform is PlatformBreak)
+                    {
+                        (platform as PlatformBreak).BreakLand();
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Red Platforms now starts its break time counter when it's jumped by the player. Also fixed an fail that impeded users to go to the main menu from the pause screen.